### PR TITLE
Updated plugin to fix compilation issue.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.9.9-SNAPSHOT
+VERSION_NAME=0.9.10-SNAPSHOT
 GROUP=com.uphyca.gradle
 
 POM_DESCRIPTION=A Gradle plugin which enables AspectJ for Android builds.

--- a/plugin/src/main/groovy/com/uphyca/gradle/android/AndroidAspectJPlugin.groovy
+++ b/plugin/src/main/groovy/com/uphyca/gradle/android/AndroidAspectJPlugin.groovy
@@ -43,9 +43,9 @@ class AndroidAspectJPlugin implements Plugin<Project> {
                 }
 
                 def variantName = variant.name.capitalize()
-                def taskName = "compile${variantName}Aspectj"
+                def newTaskName = "compile${variantName}Aspectj"
 
-                def aspectjCompile = project.task(taskName, type: AspectjCompile) {
+                def aspectjCompile = project.task(newTaskName, overwrite: true, description: 'Compiles AspectJ Source', type: AspectjCompile) {
                     aspectpath = javaCompile.classpath
                     destinationDir = javaCompile.destinationDir
                     classpath = javaCompile.classpath
@@ -53,8 +53,15 @@ class AndroidAspectJPlugin implements Plugin<Project> {
                     sourceroots = javaCompile.source
                 }
 
-                aspectjCompile.dependsOn(javaCompile)
-                javaCompile.finalizedBy(aspectjCompile)
+                aspectjCompile.doFirst {
+
+                    javaCompile.destinationDir.mkdirs()
+                }
+
+                def compileAspect = project.tasks.getByName(newTaskName)
+                compileAspect.setDependsOn(variant.javaCompile.dependsOn)
+                variant.javaCompile.deleteAllActions()
+                variant.javaCompile.dependsOn compileAspect
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include 'plugin'
 project(':plugin').name = 'plugin'
 
-//include 'tests'
-//project(':tests').name = 'tests'
+include 'tests'
+project(':tests').name = 'tests'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 include 'plugin'
 project(':plugin').name = 'plugin'
 
-include 'tests'
-project(':tests').name = 'tests'
+//include 'tests'
+//project(':tests').name = 'tests'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.12.+'
-        classpath 'com.uphyca.gradle:gradle-android-aspectj-plugin:0.9.9-SNAPSHOT'
+        classpath 'com.uphyca.gradle:gradle-android-aspectj-plugin:0.9.10-SNAPSHOT'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Updated plugin to fix compilation issue that results in duplicate class members, which causes Android builds and unit tests to break. 

Using plugin version 0.9.9, Android builds and unit tests fail due to compilation errors caused by duplicate members compiled into the aspect classes. I used jad to decompile the class files produced by this plugin and found that ClassFormatError was a valid issue.

I found that this issue can be fixed by implementing task behavior found in the following gradle plugin project, which compiles aspects found in external libraries. The only modification was the addition of doFirst behavior on the aspect compilation task, because the deletion of javaCompile actions prevents the classes directories from being created.

https://github.com/casidiablo/gradle-android-aspectj/blob/master/gradle-android-aspectj/src/main/groovy/android/aspectj/AndroidAspectJPlugin.groovy

I verified that the duplicate class members are not generated using the updated plugin. Again, I used jad to verifiy via decompilation.