### PR TITLE
Prevent Re-Weaving via Java Destination Directory Deletion

### DIFF
--- a/plugin/src/main/groovy/com/uphyca/gradle/android/AndroidAspectJPlugin.groovy
+++ b/plugin/src/main/groovy/com/uphyca/gradle/android/AndroidAspectJPlugin.groovy
@@ -59,6 +59,11 @@ class AndroidAspectJPlugin implements Plugin<Project> {
 
                 aspectjCompile.doFirst {
 
+                    if (javaCompile.destinationDir.exists()) {
+
+                        javaCompile.destinationDir.deleteDir()
+                    }
+                    
                     javaCompile.destinationDir.mkdirs()
                 }
 


### PR DESCRIPTION
I observed the following build error if I didn't execute a clean task along with build

Caused by: java.lang.RuntimeException: bad WeaverState.Kind: -115.  File was :<Unknown>::0
	at org.aspectj.weaver.WeaverStateInfo.read(WeaverStateInfo.java:170)
	at org.aspectj.weaver.AjAttribute.read(AjAttribute.java:105)
	at org.aspectj.weaver.bcel.Utility.readAjAttributes(Utility.java:101)
	at org.aspectj.weaver.bcel.BcelObjectType.ensureAspectJAttributesUnpacked(BcelObjectType.java:383)
	... 84 more

In the Maven AspectJ plugin, the potential for encountering this issue is accounted for by segregating output directories to prevent this error from occurring. See http://mojo.codehaus.org/aspectj-maven-plugin/weaveDirectories.html for more details.

            <!-- Modifying output directory of default compile because non-weaved classes must be stored
                 in separate folder to not confuse ajc by reweaving already woven classes (which leads to
                 to ajc error message like "bad weaverState.Kind: -115") -->

I think the more appropriate fix would be to mimic the design of the Maven plugin, but a temporary solution is to delete the destination directory before invoking the compiler