### PR TITLE
fix: can't resolve classes in libs/*.jar of aar library

### DIFF
--- a/plugin/src/main/groovy/com/uphyca/gradle/android/AndroidAspectJPlugin.groovy
+++ b/plugin/src/main/groovy/com/uphyca/gradle/android/AndroidAspectJPlugin.groovy
@@ -50,14 +50,14 @@ class AndroidAspectJPlugin implements Plugin<Project> {
                 def newTaskName = "compile${variantName}Aspectj"
 
                 def aspectjCompile = project.task(newTaskName, overwrite: true, description: 'Compiles AspectJ Source', type: AspectjCompile) {
+                }
+
+                aspectjCompile.doFirst {
                     aspectpath = javaCompile.classpath
                     destinationDir = javaCompile.destinationDir
                     classpath = javaCompile.classpath
                     bootclasspath = bootClasspath.join(File.pathSeparator)
                     sourceroots = javaCompile.source
-                }
-
-                aspectjCompile.doFirst {
 
                     if (javaCompile.destinationDir.exists()) {
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -23,7 +23,7 @@ task wrapper(type: Wrapper) {
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 21
     buildToolsVersion "20.0.0"
 
     compileOptions {
@@ -52,4 +52,8 @@ android {
     lintOptions {
         abortOnError false
     }
+}
+
+dependencies {
+    compile 'com.android.support:appcompat-v7:21.0.3'
 }

--- a/tests/src/androidTest/java/com/uphyca/gradle/android/aspectj/MyActivityTest.java
+++ b/tests/src/androidTest/java/com/uphyca/gradle/android/aspectj/MyActivityTest.java
@@ -2,7 +2,7 @@ package com.uphyca.gradle.android.aspectj;
 
 import android.content.Intent;
 import android.test.ActivityUnitTestCase;
-import junit.framework.TestCase;
+import android.view.ContextThemeWrapper;
 
 public class MyActivityTest extends ActivityUnitTestCase<MyActivity> {
 
@@ -15,6 +15,10 @@ public class MyActivityTest extends ActivityUnitTestCase<MyActivity> {
     public void setUp() throws Exception {
         super.setUp();
 
+        // copy from http://stackoverflow.com/questions/22364433/activityunittestcase-and-startactivity-with-actionbaractivity
+        ContextThemeWrapper context =
+                new ContextThemeWrapper(getInstrumentation().getTargetContext(), R.style.AppTheme);
+        setActivityContext(context);
     }
 
     public void testSayHello() throws Exception {

--- a/tests/src/main/java/com/uphyca/gradle/android/aspectj/MyActivity.java
+++ b/tests/src/main/java/com/uphyca/gradle/android/aspectj/MyActivity.java
@@ -1,13 +1,13 @@
 package com.uphyca.gradle.android.aspectj;
 
-import android.app.Activity;
+import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
 
 
-public class MyActivity extends Activity {
+public class MyActivity extends ActionBarActivity {
 
     public String sayHello() {
         return "Hello, world.";

--- a/tests/src/main/res/menu/my.xml
+++ b/tests/src/main/res/menu/my.xml
@@ -1,8 +1,9 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".MyActivity" >
     <item android:id="@+id/action_settings"
         android:title="@string/action_settings"
         android:orderInCategory="100"
-        android:showAsAction="never" />
+        app:showAsAction="never" />
 </menu>

--- a/tests/src/main/res/values/styles.xml
+++ b/tests/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
Because project settings may be updated by other tasks, delay the setting of aspectjCompileTask to use the latest information.
This fix the bug which is, cannot resolve classes in libs/*.jar of aar library like libs/internal_impl-22.0.0.jar of support-v4-22.0.0.aar.

recur bug:

1. clean the tests project
2. assemble or build the test project